### PR TITLE
Make class references dynamic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 .DS_Store
 /.rvmrc
 /.yardoc
+.idea/

--- a/lib/active_scheduler/resque_wrapper.rb
+++ b/lib/active_scheduler/resque_wrapper.rb
@@ -23,8 +23,8 @@ module ActiveScheduler
 
       schedule.each do |job, opts|
         class_name = opts[:class] || job
-        next if class_name =~ /ActiveScheduler::ResqueWrapper/
-        
+        next if class_name =~ /#{self.to_s}/
+
         klass = class_name.constantize
         next unless klass <= ActiveJob::Base
 
@@ -40,13 +40,13 @@ module ActiveScheduler
         end
 
         schedule[job] = {
-          class:        'ActiveScheduler::ResqueWrapper',
+          class:        self.to_s,
           queue:        queue,
           args: [{
-            job_class:  class_name,
-            queue_name: queue,
-            arguments:  args,
-          }]
+                   job_class:  class_name,
+                   queue_name: queue,
+                   arguments:  args,
+                 }]
         }
 
         schedule[job][:args].first.merge!({ named_args: named_args }) if named_args

--- a/spec/active_scheduler/resque_wrapper_spec.rb
+++ b/spec/active_scheduler/resque_wrapper_spec.rb
@@ -37,6 +37,29 @@ describe ActiveScheduler::ResqueWrapper do
           )
         end
       end
+
+      context 'with a custom wrapper class' do
+        class CustomWrapper < ActiveScheduler::ResqueWrapper
+        end
+
+        let(:schedule) { YAML.load_file 'spec/fixtures/simple_job.yaml' }
+
+        it "queues up a simple job" do
+          stub_jobs("SimpleJob")
+          expect(CustomWrapper.wrap(schedule)['simple_job']).to eq(
+            "class"       => "CustomWrapper",
+            "queue"       => "simple",
+            "description" => "It's a simple job.",
+            "every"       => "30s",
+            "rails_env"   => "test",
+            "args"        => [{
+               "job_class"  => "SimpleJob",
+               "queue_name" => "simple",
+               "arguments"  => ['foo-arg-1', 'foo-arg-2'],
+              }]
+           )
+        end
+      end
     end
 
     context "with a simple job json" do


### PR DESCRIPTION
ActiveScheduler has several explicit references to its wrapper class, which have no apparent reason to not be dynamic so that they can be subclassed.